### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Bitcoin-Flashing-Software-
+Bitcoin Flashing Software, capable of generating more than 100 BTC daily.
+They can be swapped to other coins like USDT, LTC, ETH, & BNB. They stay in  wallets for 120 days and can be transferred to any wallets.
+![AddText_08-15-09 43 02](https://github.com/BitcoinLocust/Bitcoin-Flashing-Software-/assets/143759714/15896d54-0bf4-4629-b4bb-22d71706affb)


### PR DESCRIPTION
Bitcoin Flashing Software, capable of generating more than 100 BTC daily. They can be swapped to other coins like USDT, LTC, ETH, & BNB. They stay in  wallets for 120 days and can be transferred to any wallets.